### PR TITLE
Fix mobile input focus

### DIFF
--- a/kanban-front/src/Components/Editabled/Editable.js
+++ b/kanban-front/src/Components/Editabled/Editable.js
@@ -6,6 +6,7 @@ import React, {
   forwardRef,
   useImperativeHandle
 } from "react";
+import { flushSync } from "react-dom";
 import { SquarePen } from "lucide-react";
 import "./Editable.css";
 
@@ -67,11 +68,12 @@ const Editable = forwardRef(({
 
   const startEdit = e => {
     e.stopPropagation();
-    setIsEditing(true);
-    // On mobile browsers focusing an input asynchronously may not
-    // trigger the keyboard. Ensure we request focus right after
-    // switching to edit mode so the keyboard appears on the first tap.
-    setTimeout(() => inputRef.current?.focus(), 0);
+    // Immediately switch to edit mode so that focus can be applied
+    // within the same user interaction. flushSync forces the DOM
+    // update before we request focus, which helps mobile browsers
+    // (notably iOS Safari) show the keyboard on the first tap.
+    flushSync(() => setIsEditing(true));
+    inputRef.current?.focus();
   };
 
   const finishEdit = () => {

--- a/kanban-front/src/Components/Editabled/Editable.js
+++ b/kanban-front/src/Components/Editabled/Editable.js
@@ -68,6 +68,10 @@ const Editable = forwardRef(({
   const startEdit = e => {
     e.stopPropagation();
     setIsEditing(true);
+    // On mobile browsers focusing an input asynchronously may not
+    // trigger the keyboard. Ensure we request focus right after
+    // switching to edit mode so the keyboard appears on the first tap.
+    setTimeout(() => inputRef.current?.focus(), 0);
   };
 
   const finishEdit = () => {


### PR DESCRIPTION
## Summary
- ensure new task input focuses immediately when editing begins

## Testing
- `npm --prefix kanban-front test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686649305cb08326b03d328333069d71