### PR TITLE
Add simple login backed by Google Sheets

### DIFF
--- a/kanban-back/package-lock.json
+++ b/kanban-back/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "googleapis": "^148.0.0",
+        "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21"
       }
     },
@@ -776,6 +777,49 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -801,6 +845,48 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -1048,6 +1134,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",

--- a/kanban-back/package.json
+++ b/kanban-back/package.json
@@ -16,5 +16,6 @@
     "express": "^5.1.0",
     "googleapis": "^148.0.0",
     "lodash": "^4.17.21"
+    , "jsonwebtoken": "^9.0.0"
   }
 }

--- a/kanban-back/server.js
+++ b/kanban-back/server.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const express = require("express");
 const cors    = require("cors");
 const axios   = require("axios");
+const jwt     = require("jsonwebtoken");
 
 const app = express();
 app.use(cors());
@@ -24,6 +25,23 @@ async function callSheetAPI(body) {
 }
 
 let tasksCache = [];
+let usersCache = [];
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+async function refreshUsersCache() {
+  try {
+    const data = await callSheetAPI({ action: 'getUsers' });
+    if (Array.isArray(data.users)) {
+      usersCache = data.users;
+      console.log(`✅ Users cache updated: ${usersCache.length} users`);
+    } else {
+      throw new Error('Invalid users response');
+    }
+  } catch (e) {
+    console.error('refreshUsersCache failed:', e.toString());
+  }
+}
 
 /**
  * Обновляет локальный кэш из Google Sheet.
@@ -45,12 +63,48 @@ async function refreshCache() {
 
 // 1) Поднять кэш сразу при старте
 refreshCache();
+refreshUsersCache();
 
 // 2) Обновлять кэш каждые 30 секунд (можете поставить любую частоту: 10 сек или 5 сек)
 setInterval(refreshCache, 30 * 1000);
+setInterval(refreshUsersCache, 60 * 1000);
+
+function authMiddleware(req, res, next) {
+  if (req.path === '/login') return next();
+  const header = req.headers.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    jwt.verify(token, JWT_SECRET);
+    next();
+  } catch (e) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+app.use('/api', authMiddleware);
 
 
 // ----- Эндпоинты для фронта -----
+
+app.post("/api/login", async (req, res) => {
+  const { login, password } = req.body || {};
+  try {
+    if (!usersCache.length) {
+      await refreshUsersCache();
+    }
+    const user = usersCache.find(u => u.login === login && u.password === password);
+    if (user) {
+      const token = jwt.sign({ login }, JWT_SECRET);
+      return res.json({ token });
+    } else {
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+  } catch (e) {
+    console.error("login error:", e.toString());
+    res.status(500).json({ error: e.toString() });
+  }
+});
 
 
 // 1) Получить доску из кэша (всё, что у нас есть следующим refreshCache)

--- a/kanban-back/server.js
+++ b/kanban-back/server.js
@@ -95,7 +95,7 @@ app.post("/api/login", async (req, res) => {
     }
     const user = usersCache.find(u => u.login === login && u.password === password);
     if (user) {
-      const token = jwt.sign({ login }, JWT_SECRET);
+      const token = jwt.sign({ login }, JWT_SECRET, { expiresIn: '5h' });
       return res.json({ token });
     } else {
       return res.status(401).json({ error: "Invalid credentials" });

--- a/kanban-front/package-lock.json
+++ b/kanban-front/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^12.8.3",
         "axios": "^1.8.4",
         "http-proxy-middleware": "^3.0.5",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.508.0",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
@@ -11821,6 +11822,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/kanban-front/package.json
+++ b/kanban-front/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^12.8.3",
     "axios": "^1.8.4",
     "http-proxy-middleware": "^3.0.5",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.508.0",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
@@ -17,7 +18,6 @@
     "react-scripts": "^5.0.1",
     "web-vitals": "^1.1.2"
   },
-  
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/kanban-front/src/App.css
+++ b/kanban-front/src/App.css
@@ -615,3 +615,10 @@ input:checked+.slider:before {
 
 
 /* ===============МОДАЛКА================ */
+/* ===== Login ===== */
+.login-page { display:flex; justify-content:center; align-items:center; height:100vh; background:var(--background); }
+.login-form { background:var(--secondary-background); padding:20px; border-radius:8px; display:flex; flex-direction:column; gap:10px; }
+.login-form input { padding:8px; }
+.login-form button { padding:8px; cursor:pointer; }
+.login-form .error { color:var(--red-700); }
+

--- a/kanban-front/src/App.js
+++ b/kanban-front/src/App.js
@@ -13,6 +13,8 @@ import "./App.css";
 
 export default function App() {
   // === Существующие стейты/рефы ===
+  const TOKEN_TTL = 5 * 60 * 60 * 1000; // 5 hours
+
   const [boards, setBoards] = useState([]);
   const [loggedIn, setLoggedIn] = useState(!!localStorage.getItem('kanban-token'));
   const [darkTheme, setDarkTheme] = useState(
@@ -42,12 +44,43 @@ export default function App() {
 
   // → ДОБАВИТЬ: ref для контейнера досок (нужно для drag-to-scroll)
   const boardsContainerRef = useRef(null);
+  const logoutTimerRef = useRef(null);
+
+  const logout = () => {
+    localStorage.removeItem('kanban-token');
+    localStorage.removeItem('kanban-token-time');
+    delete axios.defaults.headers.common['Authorization'];
+    setLoggedIn(false);
+  };
+
+  const scheduleLogout = (ms) => {
+    clearTimeout(logoutTimerRef.current);
+    logoutTimerRef.current = setTimeout(logout, ms);
+  };
+
+  const handleLogin = (token) => {
+    scheduleLogout(TOKEN_TTL);
+    setLoggedIn(true);
+  };
 
   useEffect(() => {
     const token = localStorage.getItem('kanban-token');
-    if (token) {
+    const time  = parseInt(localStorage.getItem('kanban-token-time'), 10);
+    if (token && time && Date.now() - time < TOKEN_TTL) {
       axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
+      setLoggedIn(true);
+      scheduleLogout(TOKEN_TTL - (Date.now() - time));
+    } else {
+      logout();
     }
+
+    const interceptor = axios.interceptors.response.use(r => r, err => {
+      if (err.response && err.response.status === 401) {
+        logout();
+      }
+      return Promise.reject(err);
+    });
+    return () => axios.interceptors.response.eject(interceptor);
   }, []);
 
   useEffect(() => {
@@ -336,7 +369,7 @@ export default function App() {
 
   // === JSX страницы ===
   if (!loggedIn) {
-    return <Login onLogin={() => setLoggedIn(true)} />;
+    return <Login onLogin={handleLogin} />;
   }
 
   return (

--- a/kanban-front/src/App.js
+++ b/kanban-front/src/App.js
@@ -8,11 +8,13 @@ import {
 import { DragDropContext } from "react-beautiful-dnd";
 import { Sun, Moon } from "lucide-react";
 import Board from "./Components/Board/Board";
+import Login from "./Login";
 import "./App.css";
 
 export default function App() {
   // === Существующие стейты/рефы ===
   const [boards, setBoards] = useState([]);
+  const [loggedIn, setLoggedIn] = useState(!!localStorage.getItem('kanban-token'));
   const [darkTheme, setDarkTheme] = useState(
     localStorage.getItem("kanban-theme") === "dark"
   );
@@ -40,6 +42,13 @@ export default function App() {
 
   // → ДОБАВИТЬ: ref для контейнера досок (нужно для drag-to-scroll)
   const boardsContainerRef = useRef(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('kanban-token');
+    if (token) {
+      axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
+    }
+  }, []);
 
   useEffect(() => {
     const handleResize = () => {
@@ -114,7 +123,8 @@ export default function App() {
 
   // === Загрузка данных (API) ===
   useEffect(() => {
-   axios.get("/api/board")
+    if (!loggedIn) return;
+    axios.get("/api/board")
       .then((res) => {
         const tasks = res.data.tasks || [];
         const grouped = statuses.map((st, i) => ({
@@ -125,7 +135,7 @@ export default function App() {
         setBoards(grouped);
       })
       .catch((err) => console.error("Ошибка загрузки:", err));
-  }, []);
+  }, [loggedIn]);
 
   // === Сохранение темы в localStorage ===
   useEffect(() => {
@@ -325,6 +335,10 @@ export default function App() {
   };
 
   // === JSX страницы ===
+  if (!loggedIn) {
+    return <Login onLogin={() => setLoggedIn(true)} />;
+  }
+
   return (
     <div className={`app ${darkTheme ? "dark" : ""}`}>
       <div className="app_nav">

--- a/kanban-front/src/App.js
+++ b/kanban-front/src/App.js
@@ -1,11 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
-import axios from "axios";
+import { api } from "./api";
 import { jwtDecode } from "jwt-decode";
-import {
-  addTaskToSheet,
-  updateTaskInSheet,
-  deleteTaskFromSheet
-} from "./googleSheet";
 import { DragDropContext } from "react-beautiful-dnd";
 import { Sun, Moon } from "lucide-react";
 import Board from "./Components/Board/Board";
@@ -48,7 +43,7 @@ export default function App() {
 
   const logout = () => {
     localStorage.removeItem('kanban-token');
-    delete axios.defaults.headers.common['Authorization'];
+    delete api.defaults.headers.common['Authorization'];
     setLoggedIn(false);
   };
 
@@ -73,7 +68,7 @@ export default function App() {
       try {
         const { exp } = jwtDecode(token);
         if (Date.now() < exp * 1000) {
-          axios.defaults.headers.common["Authorization"] = "Bearer " + token;
+          api.defaults.headers.common["Authorization"] = "Bearer " + token;
           setLoggedIn(true);
           scheduleLogout(exp * 1000 - Date.now());
         } else {
@@ -84,13 +79,13 @@ export default function App() {
       }
     }
 
-    const interceptor = axios.interceptors.response.use(r => r, err => {
+    const interceptor = api.interceptors.response.use(r => r, err => {
       if (err.response && err.response.status === 401) {
         logout();
       }
       return Promise.reject(err);
     });
-    return () => axios.interceptors.response.eject(interceptor);
+    return () => api.interceptors.response.eject(interceptor);
   }, []);
   useEffect(() => {
     if (!loggedIn) return;
@@ -189,7 +184,7 @@ export default function App() {
   // === Загрузка данных (API) ===
   useEffect(() => {
     if (!loggedIn) return;
-    axios.get("/api/board")
+    api.get("/board")
       .then((res) => {
         const tasks = res.data.tasks || [];
         const grouped = statuses.map((st, i) => ({
@@ -296,17 +291,7 @@ export default function App() {
           : b
       )
     );
-    axios.post("/api/addTask", { card: cardData })
-    addTaskToSheet({
-      id:          cardData.id,
-      title:       cardData.title,
-      description: cardData.description,
-      status:      cardData.status,
-      startDate:   cardData.startDate,
-      dueDate:     cardData.dueDate,
-      priority:    cardData.priority,
-      labels:      cardData.labels
-    }).catch(console.error);
+    api.post("/addTask", { card: cardData })
   };
 
   const updateCard = (boardId, cardId, updatedCard) => {
@@ -322,17 +307,7 @@ export default function App() {
           : b
       )
     );
-    axios.post("/api/editTask", { card: updatedCard })
-    updateTaskInSheet({
-      id:          updatedCard.id,
-      title:       updatedCard.title,
-      description: updatedCard.description,
-      status:      updatedCard.status,
-      startDate:   updatedCard.startDate,
-      dueDate:     updatedCard.dueDate,
-      priority:    updatedCard.priority,
-      labels:      updatedCard.labels
-    }).catch(console.error);
+    api.post("/editTask", { card: updatedCard })
   };
 
   const removeCard = (boardId, cardId) => {
@@ -343,8 +318,7 @@ export default function App() {
           : b
       )
     );
-    axios.post("/api/deleteTask", { id: cardId })
-    deleteTaskFromSheet(cardId).catch(console.error);
+    api.post("/deleteTask", { id: cardId })
   };
 
   // === Drag & Drop из react-beautiful-dnd ===
@@ -386,17 +360,7 @@ export default function App() {
       })
     );
 
-    axios.post("/api/updateTask", { card: movedCard })
-    updateTaskInSheet({
-      id:          movedCard.id,
-      title:       movedCard.title,
-      description: movedCard.description,
-      status:      movedCard.status,
-      startDate:   movedCard.startDate,
-      dueDate:     movedCard.dueDate,
-      priority:    movedCard.priority,
-      labels:      movedCard.labels,
-    }).catch(console.error);
+    api.post("/updateTask", { card: movedCard })
   };
 
   // === JSX страницы ===

--- a/kanban-front/src/App.js
+++ b/kanban-front/src/App.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import axios from "axios";
+import { jwtDecode } from "jwt-decode";
 import {
   addTaskToSheet,
   updateTaskInSheet,
@@ -13,7 +14,6 @@ import "./App.css";
 
 export default function App() {
   // === Существующие стейты/рефы ===
-  const TOKEN_TTL = 5 * 60 * 60 * 1000; // 5 hours
 
   const [boards, setBoards] = useState([]);
   const [loggedIn, setLoggedIn] = useState(!!localStorage.getItem('kanban-token'));
@@ -48,7 +48,6 @@ export default function App() {
 
   const logout = () => {
     localStorage.removeItem('kanban-token');
-    localStorage.removeItem('kanban-token-time');
     delete axios.defaults.headers.common['Authorization'];
     setLoggedIn(false);
   };
@@ -59,19 +58,30 @@ export default function App() {
   };
 
   const handleLogin = (token) => {
-    scheduleLogout(TOKEN_TTL);
+    try {
+      const { exp } = jwtDecode(token);
+      const ms = exp * 1000 - Date.now();
+      if (ms > 0) scheduleLogout(ms);
+    } catch {
+      scheduleLogout(0);
+    }
     setLoggedIn(true);
   };
-
   useEffect(() => {
-    const token = localStorage.getItem('kanban-token');
-    const time  = parseInt(localStorage.getItem('kanban-token-time'), 10);
-    if (token && time && Date.now() - time < TOKEN_TTL) {
-      axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
-      setLoggedIn(true);
-      scheduleLogout(TOKEN_TTL - (Date.now() - time));
-    } else {
-      logout();
+    const token = localStorage.getItem("kanban-token");
+    if (token) {
+      try {
+        const { exp } = jwtDecode(token);
+        if (Date.now() < exp * 1000) {
+          axios.defaults.headers.common["Authorization"] = "Bearer " + token;
+          setLoggedIn(true);
+          scheduleLogout(exp * 1000 - Date.now());
+        } else {
+          logout();
+        }
+      } catch {
+        logout();
+      }
     }
 
     const interceptor = axios.interceptors.response.use(r => r, err => {
@@ -82,6 +92,28 @@ export default function App() {
     });
     return () => axios.interceptors.response.eject(interceptor);
   }, []);
+  useEffect(() => {
+    if (!loggedIn) return;
+    const interval = setInterval(() => {
+      const t = localStorage.getItem("kanban-token");
+      if (!t) {
+        clearInterval(interval);
+        return logout();
+      }
+      try {
+        const { exp } = jwtDecode(t);
+        if (Date.now() >= exp * 1000) {
+          logout();
+          clearInterval(interval);
+        }
+      } catch {
+        logout();
+        clearInterval(interval);
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [loggedIn]);
+
 
   useEffect(() => {
     const handleResize = () => {

--- a/kanban-front/src/Login.js
+++ b/kanban-front/src/Login.js
@@ -13,7 +13,6 @@ export default function Login({ onLogin }) {
       const res = await axios.post('/api/login', { login, password });
       const token = res.data.token;
       localStorage.setItem('kanban-token', token);
-      localStorage.setItem('kanban-token-time', Date.now().toString());
       axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
       onLogin(token);
     } catch (err) {

--- a/kanban-front/src/Login.js
+++ b/kanban-front/src/Login.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import { api } from './api';
 
 export default function Login({ onLogin }) {
   const [login, setLogin] = useState('');
@@ -10,10 +10,10 @@ export default function Login({ onLogin }) {
     e.preventDefault();
     setError(null);
     try {
-      const res = await axios.post('/api/login', { login, password });
-      const token = res.data.token;
+      const { data } = await api.post('/login', { login, password });
+      const token = data.token;
       localStorage.setItem('kanban-token', token);
-      axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
+      api.defaults.headers.common['Authorization'] = 'Bearer ' + token;
       onLogin(token);
     } catch (err) {
       setError('Неверный логин или пароль');

--- a/kanban-front/src/Login.js
+++ b/kanban-front/src/Login.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+export default function Login({ onLogin }) {
+  const [login, setLogin] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await axios.post('/api/login', { login, password });
+      const token = res.data.token;
+      localStorage.setItem('kanban-token', token);
+      axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
+      onLogin();
+    } catch (err) {
+      setError('Неверный логин или пароль');
+    }
+  };
+
+  return (
+    <div className="login-page">
+      <form className="login-form" onSubmit={handleSubmit}>
+        <h2>Вход</h2>
+        {error && <div className="error">{error}</div>}
+        <input
+          type="text"
+          placeholder="Login"
+          value={login}
+          onChange={(e) => setLogin(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Войти</button>
+      </form>
+    </div>
+  );
+}

--- a/kanban-front/src/Login.js
+++ b/kanban-front/src/Login.js
@@ -13,8 +13,9 @@ export default function Login({ onLogin }) {
       const res = await axios.post('/api/login', { login, password });
       const token = res.data.token;
       localStorage.setItem('kanban-token', token);
+      localStorage.setItem('kanban-token-time', Date.now().toString());
       axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
-      onLogin();
+      onLogin(token);
     } catch (err) {
       setError('Неверный логин или пароль');
     }

--- a/kanban-front/src/api.js
+++ b/kanban-front/src/api.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: 'http://localhost:3001/api',
+});


### PR DESCRIPTION
## Summary
- add jsonwebtoken dependency
- create users cache and login endpoint in server
- verify JWT on API routes
- create Login component for frontend
- show Login page when user is not authenticated
- style login form

## Testing
- `npm test` in `kanban-back` *(fails: Error: no test specified)*
- `npm test --silent` in `kanban-front` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68855996466c83268671e9a6643ab1d9